### PR TITLE
add python and python-pip to enable builds from python projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update -qqy \
                       rpm createrepo aptly\
                       bzip2 \
                       gnupg gpgv \
+                      python \
+                      python-pip \
   && apt-get clean -qq \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && gem install fpm --no-ri --no-rdoc


### PR DESCRIPTION
just added python and python-pip to enable building python projects.
For example:

```
fpm -s python -t deb python-consul
```
